### PR TITLE
#9 Quitar seccion de “Legales” del footer

### DIFF
--- a/src/components/FooterLayout.js
+++ b/src/components/FooterLayout.js
@@ -76,6 +76,7 @@ const FooterLayout = () => {
                 <StaticImage src="../static/images/pycon-logo.svg" alt="PyCon Colombia logo" />
               </div>
             </Col>
+            {/*
             <Col xs={12} md={6} lg={3} className="footer-column">
               <div className="footer-label">Legales</div>
               <div className="footer-separator"></div>
@@ -87,6 +88,7 @@ const FooterLayout = () => {
                 ))}
               </ul>
             </Col>
+            */}
             <Col xs={12} md={6} lg={4} className="footer-column">
               <div>Otros</div>
               <div className="footer-separator"></div>


### PR DESCRIPTION
fixes #9 
<img width="1728" alt="image" src="https://github.com/PyConColombia/website-2024/assets/42823670/c22bbd50-dfb3-45dd-b101-d036523c4609">
